### PR TITLE
Implement 2048 logic

### DIFF
--- a/game/games/__tests__/two048.ts
+++ b/game/games/__tests__/two048.ts
@@ -90,6 +90,77 @@ const descriptions: {
       },
     ],
   },
+  {
+    title: "Down",
+    cases: [
+      {
+        title: "A single tile in row 0 moves to row 3",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [0, 0],
+        prevTiles: [
+          {
+            tileId: 1,
+            value: 2,
+            row: 0,
+            column: 1,
+          },
+        ],
+        applyAction: "down",
+        expectedPositions: [
+          {
+            tileId: 1,
+            value: 2,
+            row: 3,
+            column: 1,
+          },
+          {
+            tileId: 2,
+            value: 2,
+            row: 0,
+            column: 0,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Left",
+    cases: [
+      {
+        title: "Two tiles merge when moved left",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [1, 3],
+        prevTiles: [
+          { tileId: 1, value: 2, row: 0, column: 2 },
+          { tileId: 2, value: 2, row: 0, column: 3 },
+        ],
+        applyAction: "left",
+        expectedPositions: [
+          { tileId: 1, value: 4, row: 0, column: 0 },
+          { tileId: 3, value: 2, row: 1, column: 3 },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Right",
+    cases: [
+      {
+        title: "No new tile spawns when no tiles move",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [0, 0],
+        prevTiles: [
+          { tileId: 1, value: 2, row: 0, column: 3 },
+          { tileId: 2, value: 4, row: 1, column: 3 },
+        ],
+        applyAction: "right",
+        expectedPositions: [
+          { tileId: 1, value: 2, row: 0, column: 3 },
+          { tileId: 2, value: 4, row: 1, column: 3 },
+        ],
+      },
+    ],
+  },
 ];
 
 function stateFromTilePositions(positions: TilePosition[]): Types.GameState {

--- a/game/games/__tests__/two048.ts
+++ b/game/games/__tests__/two048.ts
@@ -88,6 +88,120 @@ const descriptions: {
           },
         ],
       },
+      {
+        title: "Merging 2 tiles next to each other works",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [3, 3],
+        prevTiles: [
+          {
+            tileId: 1,
+            value: 2,
+            row: 0,
+            column: 0,
+          },
+          {
+            tileId: 2,
+            value: 2,
+            row: 1,
+            column: 0,
+          },
+        ],
+        applyAction: "up",
+        expectedPositions: [
+          {
+            tileId: 1,
+            value: 4,
+            row: 0,
+            column: 0,
+          },
+          {
+            tileId: 3,
+            value: 2,
+            row: 3,
+            column: 3,
+          },
+        ],
+      },
+      {
+        title: "Merging 2 tiles with a gap inbetween works",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [3, 3],
+        prevTiles: [
+          {
+            tileId: 1,
+            value: 2,
+            row: 0,
+            column: 0,
+          },
+          {
+            tileId: 2,
+            value: 2,
+            row: 2,
+            column: 0,
+          },
+        ],
+        applyAction: "up",
+        expectedPositions: [
+          {
+            tileId: 1,
+            value: 4,
+            row: 0,
+            column: 0,
+          },
+          {
+            tileId: 3,
+            value: 2,
+            row: 3,
+            column: 3,
+          },
+        ],
+      },
+      {
+        title: "3 same tiles merges the first 2 only",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [3, 3],
+        prevTiles: [
+          {
+            tileId: 1,
+            value: 2,
+            row: 0,
+            column: 0,
+          },
+          {
+            tileId: 2,
+            value: 2,
+            row: 1,
+            column: 0,
+          },
+          {
+            tileId: 3,
+            value: 2,
+            row: 2,
+            column: 0,
+          },
+        ],
+        applyAction: "up",
+        expectedPositions: [
+          {
+            tileId: 1,
+            value: 4,
+            row: 0,
+            column: 0,
+          },
+          {
+            tileId: 3,
+            value: 2,
+            row: 1,
+            column: 0,
+          },
+          {
+            tileId: 4,
+            value: 2,
+            row: 3,
+            column: 3,
+          },
+        ],
+      },
     ],
   },
   {

--- a/game/games/two048.ts
+++ b/game/games/two048.ts
@@ -1,5 +1,7 @@
 import * as Types from "@/game/Game.types";
 import spawnTile from "@/game/utils/spawnTile";
+import createPositionMap from "@/game/utils/createPositionMap";
+import getAvailablePositions from "@/game/utils/getAvailablePositions";
 
 export function getColorsFromValue(value: number): {
   backgroundColor: string;
@@ -72,8 +74,129 @@ const getInitState: Types.GetInitState = ({ rand, gridSize }) => {
 };
 
 const applyMove: Types.ApplyMove = ({ state, direction, gridSize, rand }) => {
-  // TODO: Fill me in
-  return state;
+  const tiles: Types.Tile[] = state.tiles.map((t) => ({ ...t, mergedFrom: null }));
+  const positionMap = createPositionMap(tiles);
+  const removed = new Set<Types.TileId>();
+  let scoreIncrease = 0;
+  let changed = false;
+
+  function merge(target: Types.Tile, source: Types.Tile) {
+    removed.add(source.id);
+    target.value *= 2;
+    const colors = getColorsFromValue(target.value);
+    target.backgroundColor = colors.backgroundColor;
+    target.textColor = colors.textColor;
+    target.mergedFrom = [target.id, source.id];
+    scoreIncrease += target.value;
+    if (source.position[0] !== target.position[0] || source.position[1] !== target.position[1]) {
+      changed = true;
+    }
+  }
+
+  function move(tile: Types.Tile, row: number, column: number) {
+    if (tile.position[0] !== row || tile.position[1] !== column) {
+      changed = true;
+      tile.position = [row, column];
+    }
+  }
+
+  const rows = gridSize.rows;
+  const cols = gridSize.columns;
+
+  if (direction === "up" || direction === "down") {
+    for (let col = 0; col < cols; col++) {
+      const columnTiles: Types.Tile[] = [];
+      const rIter = direction === "up" ? [0, rows, 1] : [rows - 1, -1, -1];
+      for (let r = rIter[0]; r !== rIter[1]; r += rIter[2]) {
+        const tile = positionMap[r]?.[col];
+        if (tile) columnTiles.push(tile);
+      }
+
+      let targetRow = direction === "up" ? 0 : rows - 1;
+      let lastTile: Types.Tile | null = null;
+
+      columnTiles.forEach((tile) => {
+        if (lastTile && lastTile.value === tile.value && !lastTile.mergedFrom) {
+          merge(lastTile, tile);
+        } else {
+          move(tile, targetRow, col);
+          lastTile = tile;
+          targetRow += direction === "up" ? 1 : -1;
+        }
+      });
+    }
+  } else {
+    for (let row = 0; row < rows; row++) {
+      const rowTiles: Types.Tile[] = [];
+      const cIter = direction === "left" ? [0, cols, 1] : [cols - 1, -1, -1];
+      for (let c = cIter[0]; c !== cIter[1]; c += cIter[2]) {
+        const tile = positionMap[row]?.[c];
+        if (tile) rowTiles.push(tile);
+      }
+
+      let targetCol = direction === "left" ? 0 : cols - 1;
+      let lastTile: Types.Tile | null = null;
+
+      rowTiles.forEach((tile) => {
+        if (lastTile && lastTile.value === tile.value && !lastTile.mergedFrom) {
+          merge(lastTile, tile);
+        } else {
+          move(tile, row, targetCol);
+          lastTile = tile;
+          targetCol += direction === "left" ? 1 : -1;
+        }
+      });
+    }
+  }
+
+  let newTiles = tiles.filter((t) => !removed.has(t.id));
+
+  let nextState: Types.GameState = {
+    ...state,
+    tiles: newTiles,
+    score: state.score + scoreIncrease,
+  };
+
+  if (changed) {
+    const value = rand() < 0.9 ? 2 : 4;
+    const spawned = spawnTile({
+      state: nextState,
+      gridSize,
+      rand,
+      tile: { value, ...getColorsFromValue(value) },
+    });
+
+    if (spawned) nextState = spawned;
+  }
+
+  // check win
+  if (nextState.tiles.some((t) => t.value >= 2048)) {
+    nextState.state = "won";
+  } else {
+    // check lost
+    const available = getAvailablePositions({ gridSize, state: nextState });
+    if (available.length === 0) {
+      const map = createPositionMap(nextState.tiles);
+      let movesLeft = false;
+      outer: for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+          const tile = map[r]?.[c];
+          if (!tile) continue;
+          const right = map[r]?.[c + 1];
+          const down = map[r + 1]?.[c];
+          if ((right && right.value === tile.value) || (down && down.value === tile.value)) {
+            movesLeft = true;
+            break outer;
+          }
+        }
+      }
+      if (!movesLeft) {
+        nextState.state = "lost";
+      }
+    }
+  }
+
+  return nextState;
 };
 
 const gameConfig: Types.GameConfig = {


### PR DESCRIPTION
## Summary
- implement full 2048 move logic
- extend test coverage for 2048 moves and merges

## Testing
- `npm test --silent` *(fails: jest not found)*