### PR TITLE
Add grid size pickers

### DIFF
--- a/components/game/Game.context.tsx
+++ b/components/game/Game.context.tsx
@@ -52,6 +52,7 @@ type GameContext = {
   reset: () => void;
   setRows: (rows: number) => void;
   setColumns: (columns: number) => void;
+  setGame: (game: GameTypes.GameConfig) => void;
   columns: number;
   rows: number;
   score: SharedValue<number>;
@@ -129,6 +130,20 @@ export function useGameState(): GameTypes.State {
   return state ?? fallback;
 }
 
+export function useSetGame() {
+  const { setGame, game } = React.useContext(Context) ?? {};
+
+  return {
+    setGame: React.useCallback(
+      (game: GameTypes.GameConfig) => {
+        setGame?.(game);
+      },
+      [setGame]
+    ),
+    game,
+  };
+}
+
 function getCollapsingFromDirection(direction: GameTypes.Direction) {
   switch (direction) {
     case "up":
@@ -146,7 +161,7 @@ function getCollapsingFromDirection(direction: GameTypes.Direction) {
 
 export function GameProvider(props: { children: React.ReactNode }) {
   const { vibrate } = useVibrate();
-  const [game] = React.useState<GameTypes.GameConfig>(defaultGame);
+  const [game, setGame] = React.useState<GameTypes.GameConfig>(defaultGame);
 
   const animationProgress = useSharedValue<number>(0);
 
@@ -450,6 +465,7 @@ export function GameProvider(props: { children: React.ReactNode }) {
       rows,
       score,
       state,
+      setGame,
     }),
     [
       game,

--- a/components/game/Game.context.tsx
+++ b/components/game/Game.context.tsx
@@ -50,6 +50,8 @@ type GameContext = {
     }
   ) => void;
   reset: () => void;
+  setRows: (rows: number) => void;
+  setColumns: (columns: number) => void;
   columns: number;
   rows: number;
   score: SharedValue<number>;
@@ -96,6 +98,12 @@ export function useActionHandlers() {
   return { handleAction, reset };
 }
 
+export function useSetGridSize() {
+  const { setRows, setColumns } = React.useContext(Context) ?? {};
+
+  return { setRows, setColumns };
+}
+
 export function useGridSize() {
   const { columns, rows } = React.useContext(Context) ?? {
     columns: 4,
@@ -129,8 +137,10 @@ export function GameProvider(props: { children: React.ReactNode }) {
 
   const rand = React.useMemo(() => withRand(generateSeed()), []);
 
-  const columns = 4;
-  const rows = 8;
+  const [columns, setColumns] = React.useState<number>(
+    game.defaultGridSize.columns
+  );
+  const [rows, setRows] = React.useState<number>(game.defaultGridSize.rows);
 
   const callbacks = React.useRef<Record<GameTypes.TileId, TileSubscriber>>({});
 
@@ -386,6 +396,8 @@ export function GameProvider(props: { children: React.ReactNode }) {
       animationProgress,
       handleAction,
       reset,
+      setRows,
+      setColumns,
       columns,
       rows,
       score,
@@ -398,6 +410,8 @@ export function GameProvider(props: { children: React.ReactNode }) {
       getTile,
       handleAction,
       reset,
+      setRows,
+      setColumns,
       columns,
       rows,
       score,

--- a/components/game/Game.context.tsx
+++ b/components/game/Game.context.tsx
@@ -12,8 +12,8 @@ import {
   withTiming,
 } from "react-native-reanimated";
 
-const duration = 250;
-const pendingDuration = 100;
+const duration = 300;
+const pendingDuration = duration / 2;
 
 export type TileState = {
   position: GameTypes.Position;
@@ -23,7 +23,7 @@ export type TileState = {
 };
 
 export type TileAnimatingState = TileState & {
-  collapsing: "x" | "y" | null;
+  collapsing: "top" | "bottom" | "left" | "right" | "center" | null;
   scalePop: boolean;
 };
 
@@ -127,6 +127,21 @@ export function useGameState(): GameTypes.State {
   const { state } = React.useContext(Context) ?? {};
 
   return state ?? fallback;
+}
+
+function getCollapsingFromDirection(direction: GameTypes.Direction) {
+  switch (direction) {
+    case "up":
+      return "top";
+    case "down":
+      return "bottom";
+    case "left":
+      return "left";
+    case "right":
+      return "right";
+    default:
+      return null;
+  }
 }
 
 export function GameProvider(props: { children: React.ReactNode }) {
@@ -304,8 +319,7 @@ export function GameProvider(props: { children: React.ReactNode }) {
                 textColor: tile.textColor,
                 position: mergedToTile.position,
                 scalePop: false,
-                collapsing:
-                  direction === "up" || direction === "down" ? "y" : "x",
+                collapsing: getCollapsingFromDirection(direction) ?? "center",
               };
             });
 
@@ -322,6 +336,40 @@ export function GameProvider(props: { children: React.ReactNode }) {
               scalePop: false,
               backgroundColor,
               textColor,
+            };
+
+            break;
+          }
+          case "remove": {
+            const { tileId } = diff.payload;
+
+            const tile = getTile(tileId, currentState.current);
+
+            if (!tile) {
+              break;
+            }
+
+            newTileStates[tileId] = {
+              ...tile,
+              collapsing: "center",
+              scalePop: false,
+            };
+
+            break;
+          }
+          case "value-change": {
+            const { tileId } = diff.payload;
+
+            const tile = getTile(tileId, nextState);
+
+            if (!tile) {
+              break;
+            }
+
+            newTileStates[tileId] = {
+              ...tile,
+              collapsing: null,
+              scalePop: true,
             };
 
             break;

--- a/components/game/Game.tsx
+++ b/components/game/Game.tsx
@@ -20,7 +20,7 @@ function ConnectedGame(props: GameProps): React.ReactNode {
   const score = useScore();
   const scoreColor = useSharedValue<string | null>("white");
   const gameState = useGameState();
-  const { panGesture, reset } = useGameController();
+  const { gesture, reset } = useGameController();
   const { setRows, setColumns } = useSetGridSize();
   const { rows, columns } = useGridSize();
   const insets = useSafeAreaInsets();
@@ -104,7 +104,7 @@ function ConnectedGame(props: GameProps): React.ReactNode {
       </View>
 
       <GridConnected
-        gesture={panGesture}
+        gesture={gesture}
         availableHeight={availableSize.height}
         availableWidth={availableSize.width}
       />

--- a/components/game/Game.tsx
+++ b/components/game/Game.tsx
@@ -4,7 +4,9 @@ import {
   useGameState,
   useGridSize,
   useSetGridSize,
+  useSetGame,
 } from "@/components/game/Game.context";
+import games from "@/game/games";
 import GridConnected from "@/components/game/grid/GridConnected";
 import React from "react";
 import { Button, Dimensions, StyleSheet, Text, View } from "react-native";
@@ -24,6 +26,8 @@ function ConnectedGame(props: GameProps): React.ReactNode {
   const { setRows, setColumns } = useSetGridSize();
   const { rows, columns } = useGridSize();
   const insets = useSafeAreaInsets();
+  const { game, setGame } = useSetGame();
+  const selectedGame = game?.name;
 
   const [size, setSize] = React.useState<{
     width: number;
@@ -64,7 +68,7 @@ function ConnectedGame(props: GameProps): React.ReactNode {
   const footerStyle = React.useMemo(
     () =>
       StyleSheet.flatten([
-        styles.reset,
+        styles.footer,
         {
           height: footerHeight,
         },
@@ -92,48 +96,102 @@ function ConnectedGame(props: GameProps): React.ReactNode {
     return Array.from({ length: 19 }, (_, i) => i + 2);
   }, []);
 
-  return (
-    <View style={styles.container} onLayout={onLayout}>
-      <View style={headerStyle}>
-        <Number color={scoreColor} value={score} fontSize={20} maxDigits={10} />
-        {gameState !== "playing" && (
-          <Text style={styles.text}>
-            {gameState === "won" ? "You Won!" : "You Lost!"}
-          </Text>
-        )}
-      </View>
+  const [settingsVisible, setSettingsVisible] = React.useState(false);
+  const openSettings = React.useCallback(() => {
+    setSettingsVisible(true);
+  }, []);
 
-      <GridConnected
-        gesture={gesture}
-        availableHeight={availableSize.height}
-        availableWidth={availableSize.width}
-      />
-      {reset && (
+  const closeSettings = React.useCallback(() => {
+    setSettingsVisible(false);
+  }, []);
+
+  return (
+    <>
+      <View style={styles.container} onLayout={onLayout}>
+        <View style={headerStyle}>
+          <Number
+            color={scoreColor}
+            value={score}
+            fontSize={20}
+            maxDigits={10}
+          />
+          {gameState !== "playing" && (
+            <Text style={styles.text}>
+              {gameState === "won" ? "You Won!" : "You Lost!"}
+            </Text>
+          )}
+        </View>
+
+        <GridConnected
+          gesture={gesture}
+          availableHeight={availableSize.height}
+          availableWidth={availableSize.width}
+        />
+
         <View style={footerStyle}>
-          <View style={styles.pickers}>
-            <Picker
-              style={styles.picker}
-              selectedValue={rows}
-              onValueChange={onRowsChange}
-            >
-              {pickerValues.map((v) => (
-                <Picker.Item key={`row-${v}`} label={String(v)} value={v} />
-              ))}
-            </Picker>
-            <Picker
-              style={styles.picker}
-              selectedValue={columns}
-              onValueChange={onColumnsChange}
-            >
-              {pickerValues.map((v) => (
-                <Picker.Item key={`col-${v}`} label={String(v)} value={v} />
-              ))}
-            </Picker>
+          <View style={styles.reset}>
+            <Button title="Settings" onPress={openSettings} />
           </View>
-          <Button title="reset" onPress={reset} />
+          {reset && (
+            <View style={styles.reset}>
+              <Button title="reset" onPress={reset} />
+            </View>
+          )}
+        </View>
+      </View>
+      {settingsVisible && (
+        <View style={styles.modal}>
+          <Button title="Close" onPress={closeSettings} />
+          <View style={styles.pickers}>
+            <Text style={styles.text}>Grid Size</Text>
+            <View style={styles.pickerContainer}>
+              <Text style={styles.text}>Rows</Text>
+              <Picker
+                style={styles.picker}
+                selectedValue={rows}
+                onValueChange={onRowsChange}
+              >
+                {pickerValues.map((v) => (
+                  <Picker.Item key={`row-${v}`} label={String(v)} value={v} />
+                ))}
+              </Picker>
+            </View>
+            <View style={styles.pickerContainer}>
+              <Text style={styles.text}>Columns</Text>
+              <Picker
+                style={styles.picker}
+                selectedValue={columns}
+                onValueChange={onColumnsChange}
+              >
+                {pickerValues.map((v) => (
+                  <Picker.Item key={`col-${v}`} label={String(v)} value={v} />
+                ))}
+              </Picker>
+            </View>
+          </View>
+          <View style={styles.pickers}>
+            <Text style={styles.text}>Game</Text>
+            <View style={styles.pickerContainer}>
+              <Picker
+                style={styles.picker}
+                selectedValue={selectedGame}
+                onValueChange={(newSelectedGame: string) =>
+                  setGame(games.find((g) => g.name === newSelectedGame)!)
+                }
+              >
+                {games.map((game) => (
+                  <Picker.Item
+                    key={game.name}
+                    label={game.name}
+                    value={game.name}
+                  />
+                ))}
+              </Picker>
+            </View>
+          </View>
         </View>
       )}
-    </View>
+    </>
   );
 }
 
@@ -163,15 +221,33 @@ const styles = StyleSheet.create({
     color: "white",
     marginLeft: 10,
   },
-  reset: {
+  footer: {
     paddingTop: 10,
+    flexDirection: "row",
   },
-  pickers: {
+  reset: {
+    marginHorizontal: 10,
+  },
+  pickers: {},
+  pickerContainer: {
     flexDirection: "row",
     justifyContent: "space-between",
-    width: "100%",
+    marginBottom: 20,
   },
   picker: {
+    width: 200,
+    backgroundColor: "white",
+  },
+  modal: {
+    backgroundColor: "black",
     flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 1000,
   },
 });

--- a/components/game/Game.tsx
+++ b/components/game/Game.tsx
@@ -2,10 +2,13 @@ import {
   GameProvider,
   useScore,
   useGameState,
+  useGridSize,
+  useSetGridSize,
 } from "@/components/game/Game.context";
 import GridConnected from "@/components/game/grid/GridConnected";
 import React from "react";
 import { Button, Dimensions, StyleSheet, Text, View } from "react-native";
+import { Picker } from "@react-native-picker/picker";
 import useGameController from "./hooks/useGameController";
 import Number from "@/components/game/Number";
 import { useSharedValue } from "react-native-reanimated";
@@ -18,6 +21,8 @@ function ConnectedGame(props: GameProps): React.ReactNode {
   const scoreColor = useSharedValue<string | null>("white");
   const gameState = useGameState();
   const { panGesture, reset } = useGameController();
+  const { setRows, setColumns } = useSetGridSize();
+  const { rows, columns } = useGridSize();
   const insets = useSafeAreaInsets();
 
   const [size, setSize] = React.useState<{
@@ -67,6 +72,26 @@ function ConnectedGame(props: GameProps): React.ReactNode {
     [footerHeight]
   );
 
+  const onRowsChange = React.useCallback(
+    (value: number) => {
+      setRows?.(value);
+      reset?.();
+    },
+    [setRows, reset]
+  );
+
+  const onColumnsChange = React.useCallback(
+    (value: number) => {
+      setColumns?.(value);
+      reset?.();
+    },
+    [setColumns, reset]
+  );
+
+  const pickerValues = React.useMemo(() => {
+    return Array.from({ length: 19 }, (_, i) => i + 2);
+  }, []);
+
   return (
     <View style={styles.container} onLayout={onLayout}>
       <View style={headerStyle}>
@@ -85,6 +110,26 @@ function ConnectedGame(props: GameProps): React.ReactNode {
       />
       {reset && (
         <View style={footerStyle}>
+          <View style={styles.pickers}>
+            <Picker
+              style={styles.picker}
+              selectedValue={rows}
+              onValueChange={onRowsChange}
+            >
+              {pickerValues.map((v) => (
+                <Picker.Item key={`row-${v}`} label={String(v)} value={v} />
+              ))}
+            </Picker>
+            <Picker
+              style={styles.picker}
+              selectedValue={columns}
+              onValueChange={onColumnsChange}
+            >
+              {pickerValues.map((v) => (
+                <Picker.Item key={`col-${v}`} label={String(v)} value={v} />
+              ))}
+            </Picker>
+          </View>
           <Button title="reset" onPress={reset} />
         </View>
       )}
@@ -120,5 +165,13 @@ const styles = StyleSheet.create({
   },
   reset: {
     paddingTop: 10,
+  },
+  pickers: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    width: "100%",
+  },
+  picker: {
+    flex: 1,
   },
 });

--- a/components/game/grid/Grid.tsx
+++ b/components/game/grid/Grid.tsx
@@ -2,13 +2,17 @@ import TileConnected from "@/components/game/tile/TileConnected";
 import * as GameTypes from "@/game/Game.types";
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import { GestureDetector, GestureType } from "react-native-gesture-handler";
+import {
+  ComposedGesture,
+  GestureDetector,
+  GestureType,
+} from "react-native-gesture-handler";
 import { useSharedValue } from "react-native-reanimated";
 
 export interface GridProps {
   rows: number;
   columns: number;
-  gesture: GestureType;
+  gesture: GestureType | ComposedGesture;
   tileIds: GameTypes.TileId[];
   availableHeight: number;
   availableWidth: number;
@@ -90,6 +94,19 @@ export default React.memo(function Grid({
     [columns]
   );
 
+  const tiles = React.useMemo(
+    () =>
+      tileIds.map((tileId, i) => (
+        <TileConnected
+          key={`tile-${tileId}`}
+          id={tileId}
+          size={sizeSharedValue}
+          style={{ zIndex: tileIds.length - i }}
+        />
+      )),
+    [tileIds, sizeSharedValue]
+  );
+
   return (
     <GestureDetector gesture={gesture}>
       <View style={containerStyle}>
@@ -102,13 +119,7 @@ export default React.memo(function Grid({
             ))}
           </View>
         ))}
-        {tileIds.map((tileId) => (
-          <TileConnected
-            key={`tile-${tileId}`}
-            id={tileId}
-            size={sizeSharedValue}
-          />
-        ))}
+        {tiles}
       </View>
     </GestureDetector>
   );

--- a/components/game/hooks/useGameController.ts
+++ b/components/game/hooks/useGameController.ts
@@ -24,6 +24,10 @@ export default function useGameController() {
         case "ArrowRight":
           handleAction?.("right");
           break;
+        case "Enter":
+        case " ":
+          handleAction?.("tap");
+          break;
       }
     };
 
@@ -34,27 +38,52 @@ export default function useGameController() {
     };
   }, [handleAction]);
 
-  const panGesture = Gesture.Pan().onEnd((e) => {
-    const { translationX, translationY } = e;
+  const tapGesture = React.useMemo(
+    () =>
+      Gesture.Tap()
+        .maxDuration(250) // must be a short press
+        .maxDeltaX(10)
+        .maxDeltaY(10)
+        .onEnd(() => {
+          if (handleAction) {
+            runOnJS(handleAction)("tap");
+          }
+        }),
+    [handleAction]
+  );
 
-    const absX = Math.abs(translationX);
-    const absY = Math.abs(translationY);
+  const panGesture = React.useMemo(
+    () =>
+      Gesture.Pan()
+        .minDistance(10)
+        .onEnd((e) => {
+          const { translationX, translationY } = e;
 
-    let direction: GameTypes.Direction | null = null;
+          const absX = Math.abs(translationX);
+          const absY = Math.abs(translationY);
 
-    if (absX > absY && absX > 20) {
-      direction = translationX > 0 ? "right" : "left";
-    } else if (absY > 20) {
-      direction = translationY > 0 ? "down" : "up";
-    }
+          let direction: GameTypes.Direction | null = null;
 
-    if (direction && handleAction) {
-      runOnJS(handleAction)(direction);
-    }
-  });
+          if (absX > absY && absX > 20) {
+            direction = translationX > 0 ? "right" : "left";
+          } else if (absY > 20) {
+            direction = translationY > 0 ? "down" : "up";
+          }
+
+          if (direction && handleAction) {
+            runOnJS(handleAction)(direction);
+          }
+        }),
+    [handleAction]
+  );
+
+  const gesture = React.useMemo(
+    () => Gesture.Race(panGesture, tapGesture),
+    [tapGesture, panGesture]
+  );
 
   return {
-    panGesture,
+    gesture,
     handleAction,
     reset,
   };

--- a/components/game/tile/TileConnected.tsx
+++ b/components/game/tile/TileConnected.tsx
@@ -201,8 +201,9 @@ export default React.memo(function TileConnected({
           }
         }
 
-        // opacity = interpolate(animationProgress.value, [0, 1], [1, 0]);
-        opacity = 1;
+        // Animating opacity works better when merging from more than 1 tile away
+        opacity = interpolate(animationProgress.value, [0, 1], [1, 0]);
+        // opacity = 1;
       } else if (nextState.value.scalePop) {
         // This tile is consuming some other tiles so pop it
         opacity = 1;

--- a/game/Game.types.ts
+++ b/game/Game.types.ts
@@ -21,7 +21,7 @@ export type GameState = {
   state: State;
 };
 
-export type Direction = "up" | "down" | "left" | "right";
+export type Direction = "up" | "down" | "left" | "right" | "tap";
 
 export type GridSize = {
   rows: number;
@@ -41,6 +41,7 @@ export type ApplyMove = (props: {
 }) => GameState;
 
 export type GameConfig = {
+  supportedActions: Direction[];
   name: string;
   getInitState: GetInitState;
   applyMove: ApplyMove;
@@ -80,6 +81,27 @@ export type DiffSpawn = CreateDiffType<
   }
 >;
 
-export type Diff = DiffMove | DiffMerge | DiffSpawn;
+export type DiffRemove = CreateDiffType<
+  "remove",
+  {
+    tileId: TileId;
+  }
+>;
+
+export type DiffValueChange = CreateDiffType<
+  "value-change",
+  {
+    tileId: TileId;
+    prevValue: Value;
+    newValue: Value;
+  }
+>;
+
+export type Diff =
+  | DiffMove
+  | DiffMerge
+  | DiffSpawn
+  | DiffRemove
+  | DiffValueChange;
 
 export type Rand = () => number;

--- a/game/games/index.ts
+++ b/game/games/index.ts
@@ -1,5 +1,6 @@
 import two048 from "./two048";
+import numberRogue from "./numberRogue";
 
-export const defaultGame = two048;
+export const defaultGame = numberRogue;
 
-export default [two048];
+export default [two048, numberRogue];

--- a/game/games/numberRogue.ts
+++ b/game/games/numberRogue.ts
@@ -1,0 +1,412 @@
+import * as Types from "@/game/Game.types";
+import getFreeTileId from "@/game/utils/getFreeTileId";
+
+const supportedActions: Types.Direction[] = [
+  "up",
+  "down",
+  "left",
+  "right",
+  "tap",
+];
+
+const heroColor = "white";
+const enemyColor = "red";
+
+const getInitState: Types.GetInitState = ({ rand, gridSize }) => {
+  let state: Types.GameState | null = {
+    tiles: [],
+    score: 0,
+    state: "playing",
+  };
+
+  state = {
+    ...state,
+    tiles: [
+      ...state.tiles,
+      {
+        backgroundColor: heroColor,
+        textColor: "black",
+        id: getFreeTileId(state),
+        position: [3, 1],
+        value: 5,
+        mergedFrom: null,
+      },
+    ],
+  };
+
+  state = {
+    ...state,
+    tiles: [
+      ...state.tiles,
+      {
+        backgroundColor: enemyColor,
+        textColor: "black",
+        id: getFreeTileId(state),
+        position: [0, 2],
+        value: 2,
+        mergedFrom: null,
+      },
+    ],
+  };
+
+  state = {
+    ...state,
+    tiles: [
+      ...state.tiles,
+      {
+        backgroundColor: enemyColor,
+        textColor: "black",
+        id: getFreeTileId(state),
+        position: [1, 0],
+        value: 2,
+        mergedFrom: null,
+      },
+    ],
+  };
+
+  return state;
+};
+
+function getHeroPosition(state: Types.GameState): Types.Position {
+  const heroTile = state.tiles.find(
+    (tile) => tile.backgroundColor === heroColor
+  );
+
+  if (!heroTile) {
+    throw new Error("Hero tile not found in the game state.");
+  }
+
+  return heroTile.position;
+}
+
+// Returns the next hero position based on the direction as long as it is a valid position on the
+// grid. We don't care about other tiles at this stage
+function getNextHeroPosition({
+  state,
+  direction,
+  gridSize,
+}: {
+  state: Types.GameState;
+  direction: Types.Direction;
+  gridSize: Types.GridSize;
+}): Types.Position | null {
+  const heroPosition = getHeroPosition(state);
+
+  const nextPosition: Types.Position = [...heroPosition];
+  switch (direction) {
+    case "up":
+      nextPosition[0] -= 1;
+      break;
+    case "down":
+      nextPosition[0] += 1;
+      break;
+    case "left":
+      nextPosition[1] -= 1;
+      break;
+    case "right":
+      nextPosition[1] += 1;
+      break;
+    default:
+      return null;
+  }
+
+  // Check if the next position is within the grid bounds
+  if (
+    nextPosition[0] < 0 ||
+    nextPosition[0] >= gridSize.rows ||
+    nextPosition[1] < 0 ||
+    nextPosition[1] >= gridSize.columns
+  ) {
+    return null; // No move
+  }
+
+  return nextPosition;
+}
+
+function getTileAtPosition({
+  state,
+  position,
+}: {
+  state: Types.GameState;
+  position: Types.Position;
+}): Types.Tile | null {
+  const tile = state.tiles.find(
+    (tile) =>
+      tile.position[0] === position[0] && tile.position[1] === position[1]
+  );
+
+  if (!tile) {
+    return null; // No tile at the specified position
+  }
+
+  return tile;
+}
+
+function getHeroTile(state: Types.GameState): Types.Tile {
+  const heroTile = state.tiles.find(
+    (tile) => tile.backgroundColor === heroColor
+  );
+  if (!heroTile) {
+    throw new Error("Hero tile not found in the game state.");
+  }
+  return heroTile;
+}
+
+function moveHeroToPosition(
+  state: Types.GameState,
+  position: Types.Position
+): Types.GameState {
+  const heroTile = getHeroTile(state);
+
+  // Create a new tile with the same properties but at the new position
+  const newHeroTile: Types.Tile = {
+    ...heroTile,
+    position: position,
+  };
+
+  // Replace the old hero tile with the new one
+  const updatedTiles = state.tiles.map((tile) =>
+    tile.id === heroTile.id ? newHeroTile : tile
+  );
+
+  return {
+    ...state,
+    tiles: updatedTiles,
+  };
+}
+
+function tileType(tile: Types.Tile): "hero" | "enemy" {
+  if (tile.backgroundColor === heroColor) {
+    return "hero";
+  } else if (tile.backgroundColor === enemyColor) {
+    return "enemy";
+  } else {
+    throw new Error("Unknown tile type");
+  }
+}
+
+function resolveHeroEnemyCollision({
+  enemyTile,
+  position,
+  state,
+}: {
+  state: Types.GameState;
+  position: Types.Position;
+  enemyTile: Types.Tile;
+}): Types.GameState {
+  const tiles: Types.Tile[] = [];
+  const heroTile = getHeroTile(state);
+
+  const heroValue = heroTile.value - enemyTile.value;
+  const enemyValue = enemyTile.value - heroTile.value;
+
+  const scoreChange = Math.max(heroTile.value - enemyTile.value, 0) * 10;
+
+  state.tiles.forEach((tile) => {
+    if (tileType(tile) === "hero") {
+      if (heroValue > 0) {
+        tiles.push({
+          ...tile,
+          position: position,
+          value: heroValue,
+          mergedFrom: [enemyTile.id],
+        });
+      }
+    } else {
+      if (enemyTile.id === tile.id) {
+        if (enemyValue > 0) {
+          tiles.push({
+            ...tile,
+            position: enemyTile.position,
+            value: enemyValue,
+            mergedFrom: [heroTile.id],
+          });
+        }
+      } else {
+        tiles.push(tile);
+      }
+    }
+  });
+
+  return {
+    ...state,
+    score: state.score + scoreChange,
+    tiles,
+  };
+}
+
+// if no enemies then win, if no heroes then lose, otherwise keep playing
+function resolveEndState(state: Types.GameState): Types.GameState {
+  const heroTile = state.tiles.find(
+    (tile) => tile.backgroundColor === heroColor
+  );
+
+  const enemyTiles = state.tiles.filter(
+    (tile) => tile.backgroundColor === enemyColor
+  );
+
+  if (!heroTile) {
+    return { ...state, state: "lost" }; // No hero left, game lost
+  }
+
+  if (enemyTiles.length === 0) {
+    return { ...state, state: "won" }; // No enemies left, game won
+  }
+
+  return state; // Game continues
+}
+
+type Damage = {
+  position: Types.Position;
+  value: number;
+  target: "hero" | "enemy" | "all";
+};
+
+function damageTileId({
+  state,
+  tileId,
+  value,
+}: {
+  state: Types.GameState;
+  tileId: Types.TileId;
+  value: number;
+}): Types.GameState {
+  const tiles: Types.Tile[] = [];
+
+  state.tiles.forEach((tile) => {
+    if (tile.id === tileId) {
+      const newValue = tile.value - value;
+
+      if (newValue > 0) {
+        tiles.push({ ...tile, value: newValue });
+      }
+    } else {
+      tiles.push(tile);
+    }
+  });
+
+  return {
+    ...state,
+    tiles,
+  };
+}
+
+function dealDamage({
+  damage,
+  state,
+}: {
+  state: Types.GameState;
+  damage: Damage[];
+}): Types.GameState {
+  let nextState: Types.GameState = { ...state };
+
+  damage.forEach(({ position, value, target }) => {
+    const tile = getTileAtPosition({ state: nextState, position });
+
+    if (!tile) {
+      return; // No tile at the specified position
+    }
+
+    if (target === "hero" && tileType(tile) === "hero") {
+      nextState = damageTileId({
+        state: nextState,
+        tileId: tile.id,
+        value,
+      });
+    } else if (target === "enemy" && tileType(tile) === "enemy") {
+      nextState = damageTileId({
+        state: nextState,
+        tileId: tile.id,
+        value,
+      });
+    } else if (target === "all") {
+      nextState = damageTileId({
+        state: nextState,
+        tileId: tile.id,
+        value,
+      });
+    }
+  });
+
+  return nextState;
+}
+
+// Deals 1 damage to all adjacent enemies to the hero (orthogonal only)
+function resolveTapAction(state: Types.GameState): Types.GameState {
+  const heroTile = getHeroTile(state);
+  const heroPosition = heroTile.position;
+
+  const adjacentPositions: Types.Position[] = [
+    [heroPosition[0] - 1, heroPosition[1]], // Up
+    [heroPosition[0] + 1, heroPosition[1]], // Down
+    [heroPosition[0], heroPosition[1] - 1], // Left
+    [heroPosition[0], heroPosition[1] + 1], // Right
+  ];
+
+  const damage: Damage[] = adjacentPositions.map((position) => ({
+    position,
+    value: 1, // Deal 1 damage
+    target: "enemy", // Target only enemies
+  }));
+
+  return dealDamage({
+    state,
+    damage,
+  });
+}
+
+const applyMove: Types.ApplyMove = ({ state, direction, gridSize, rand }) => {
+  if (!supportedActions.includes(direction)) {
+    return state; // Invalid action, return current state
+  }
+
+  let nextState: Types.GameState = { ...state };
+
+  if (direction === "tap") {
+    nextState = resolveTapAction(nextState);
+  }
+
+  const nextHeroPosition = getNextHeroPosition({
+    state,
+    direction,
+    gridSize,
+  });
+
+  if (nextHeroPosition) {
+    const tileAtNextPosition = getTileAtPosition({
+      state,
+      position: nextHeroPosition,
+    });
+
+    if (!tileAtNextPosition) {
+      // console.log("Moving hero to empty position: ", nextHeroPosition);
+      nextState = moveHeroToPosition(state, nextHeroPosition);
+    } else {
+      // console.log("Collide!", nextHeroPosition);
+      nextState = resolveHeroEnemyCollision({
+        state,
+        position: nextHeroPosition,
+        enemyTile: tileAtNextPosition,
+      });
+    }
+  } else {
+    // console.log("Invalid move, hero cannot move in that direction.", direction);
+  }
+
+  nextState = resolveEndState(nextState);
+
+  return nextState;
+};
+
+const gameConfig: Types.GameConfig = {
+  supportedActions,
+  name: "Number Rogue",
+  getInitState,
+  applyMove,
+  defaultGridSize: {
+    rows: 4,
+    columns: 4,
+  },
+};
+
+export default gameConfig;

--- a/game/games/two048.ts
+++ b/game/games/two048.ts
@@ -3,6 +3,8 @@ import spawnTile from "@/game/utils/spawnTile";
 import createPositionMap from "@/game/utils/createPositionMap";
 import getAvailablePositions from "@/game/utils/getAvailablePositions";
 
+const supportedActions: Types.Direction[] = ["up", "down", "left", "right"];
+
 export function getColorsFromValue(value: number): {
   backgroundColor: string;
   textColor: string;
@@ -237,6 +239,10 @@ function resolveEndState(
 }
 
 const applyMove: Types.ApplyMove = ({ state, direction, gridSize, rand }) => {
+  if (!supportedActions.includes(direction)) {
+    return state;
+  }
+
   const { tiles, scoreIncrease, changed } = slideTiles(
     state.tiles,
     direction,
@@ -256,6 +262,7 @@ const applyMove: Types.ApplyMove = ({ state, direction, gridSize, rand }) => {
 };
 
 const gameConfig: Types.GameConfig = {
+  supportedActions,
   name: "2048",
   getInitState,
   applyMove,

--- a/game/utils/__tests__/getGameStateDiffs.ts
+++ b/game/utils/__tests__/getGameStateDiffs.ts
@@ -1,7 +1,12 @@
 import getGameStateDiffs from "../getGameStateDiffs";
 import * as Types from "@/game/Game.types";
 
-function createTile(id: number, row: number, column: number, value = 2): Types.Tile {
+function createTile(
+  id: number,
+  row: number,
+  column: number,
+  value = 2
+): Types.Tile {
   return {
     id,
     position: [row, column],
@@ -36,9 +41,17 @@ describe("getGameStateDiffs", () => {
 
   test("detects moved tile", () => {
     const prevTile = createTile(0, 0, 0, 2);
-    const prev: Types.GameState = { tiles: [prevTile], score: 0, state: "playing" };
+    const prev: Types.GameState = {
+      tiles: [prevTile],
+      score: 0,
+      state: "playing",
+    };
     const movedTile = { ...prevTile, position: [0, 1] as Types.Position };
-    const next: Types.GameState = { tiles: [movedTile], score: 0, state: "playing" };
+    const next: Types.GameState = {
+      tiles: [movedTile],
+      score: 0,
+      state: "playing",
+    };
 
     const diffs = getGameStateDiffs(prev, next);
 
@@ -70,7 +83,11 @@ describe("getGameStateDiffs", () => {
       backgroundColor: "bg-4",
       textColor: "text-4",
     };
-    const next: Types.GameState = { tiles: [mergedTile], score: 0, state: "playing" };
+    const next: Types.GameState = {
+      tiles: [mergedTile],
+      score: 0,
+      state: "playing",
+    };
 
     const diffs = getGameStateDiffs(prev, next);
 
@@ -95,5 +112,172 @@ describe("getGameStateDiffs", () => {
         },
       },
     ]);
+  });
+
+  test("detects removed tile (not merged)", () => {
+    const tileA = createTile(0, 0, 0, 2);
+    const tileB = createTile(1, 0, 1, 2);
+    const prev: Types.GameState = {
+      tiles: [tileA, tileB],
+      score: 0,
+      state: "playing",
+    };
+    // tileB is removed, tileA remains unchanged
+    const next: Types.GameState = {
+      tiles: [tileA],
+      score: 0,
+      state: "playing",
+    };
+
+    const diffs = getGameStateDiffs(prev, next);
+
+    expect(diffs).toContainEqual({
+      type: "remove",
+      payload: {
+        tileId: tileB.id,
+      },
+    });
+    // Should not contain a merge diff
+    expect(diffs.find((d) => d.type === "merge")).toBeUndefined();
+  });
+
+  test("does not return remove diff for merged tiles (only merge diff)", () => {
+    const tileA = createTile(0, 0, 0, 2);
+    const tileB = createTile(1, 0, 1, 2);
+    const prev: Types.GameState = {
+      tiles: [tileA, tileB],
+      score: 0,
+      state: "playing",
+    };
+    const mergedTile: Types.Tile = {
+      ...tileA,
+      position: [0, 1],
+      value: 4,
+      mergedFrom: [tileA.id, tileB.id],
+      backgroundColor: "bg-4",
+      textColor: "text-4",
+    };
+    const next: Types.GameState = {
+      tiles: [mergedTile],
+      score: 0,
+      state: "playing",
+    };
+
+    const diffs = getGameStateDiffs(prev, next);
+
+    // Should contain only move and merge, not remove
+    expect(diffs.find((d) => d.type === "remove")).toBeUndefined();
+    expect(diffs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "move" }),
+        expect.objectContaining({ type: "merge" }),
+      ])
+    );
+  });
+
+  test("detects value change (no move, no merge)", () => {
+    const prevTile = createTile(0, 0, 0, 2);
+    const prev: Types.GameState = {
+      tiles: [prevTile],
+      score: 0,
+      state: "playing",
+    };
+    // Only the value changes, position and id stay the same, no merge
+    const changedTile = { ...prevTile, value: 4 };
+    const next: Types.GameState = {
+      tiles: [changedTile],
+      score: 0,
+      state: "playing",
+    };
+
+    const diffs = getGameStateDiffs(prev, next);
+
+    expect(diffs).toContainEqual({
+      type: "value-change",
+      payload: {
+        tileId: changedTile.id,
+        prevValue: prevTile.value,
+        newValue: changedTile.value,
+      },
+    });
+    // Should not contain move or merge
+    expect(diffs.find((d) => d.type === "move")).toBeUndefined();
+    expect(diffs.find((d) => d.type === "merge")).toBeUndefined();
+  });
+
+  test("does not return value-change if value changed due to merge", () => {
+    const tileA = createTile(0, 0, 0, 2);
+    const tileB = createTile(1, 0, 1, 2);
+    const prev: Types.GameState = {
+      tiles: [tileA, tileB],
+      score: 0,
+      state: "playing",
+    };
+    const mergedTile: Types.Tile = {
+      ...tileA,
+      position: [0, 1],
+      value: 4,
+      mergedFrom: [tileA.id, tileB.id],
+      backgroundColor: "bg-4",
+      textColor: "text-4",
+    };
+    const next: Types.GameState = {
+      tiles: [mergedTile],
+      score: 0,
+      state: "playing",
+    };
+
+    const diffs = getGameStateDiffs(prev, next);
+
+    // Should not contain value-change, only move and merge
+    expect(diffs.find((d) => d.type === "value-change")).toBeUndefined();
+    expect(diffs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "move" }),
+        expect.objectContaining({ type: "merge" }),
+      ])
+    );
+  });
+
+  test("does not return merge diff if mergedFrom did not change (should only return move)", () => {
+    // Simulate a tile that already had mergedFrom in prev, and in next it just moves but mergedFrom is unchanged
+    const prevTile: Types.Tile = {
+      id: 0,
+      position: [0, 0],
+      value: 4,
+      mergedFrom: [1, 2],
+      backgroundColor: "bg-4",
+      textColor: "text-4",
+    };
+    const nextTile: Types.Tile = {
+      ...prevTile,
+      position: [0, 1], // moved
+      // mergedFrom is the same as before
+    };
+    const prev: Types.GameState = {
+      tiles: [prevTile],
+      score: 0,
+      state: "playing",
+    };
+    const next: Types.GameState = {
+      tiles: [nextTile],
+      score: 0,
+      state: "playing",
+    };
+
+    const diffs = getGameStateDiffs(prev, next);
+
+    // Should only return move, not merge
+    expect(diffs).toEqual([
+      {
+        type: "move",
+        payload: {
+          tileId: nextTile.id,
+          fromPosition: prevTile.position,
+          toPosition: nextTile.position,
+        },
+      },
+    ]);
+    expect(diffs.find((d) => d.type === "merge")).toBeUndefined();
   });
 });

--- a/game/utils/getGameStateDiffs.ts
+++ b/game/utils/getGameStateDiffs.ts
@@ -9,6 +9,7 @@ export default function getGameStateDiffs(
   const diffs: Types.Diff[] = [];
 
   const prevTilesMap = createTileMap(prevState.tiles);
+  const nextTilesMap = createTileMap(nextState.tiles);
 
   // Check for moved tiles
   for (const nextTile of nextState.tiles) {
@@ -26,16 +27,20 @@ export default function getGameStateDiffs(
     }
   }
 
-  // Check for merged tiles
+  // Check for merged tiles (only if mergedFrom changed from prev to next)
   for (const nextTile of nextState.tiles) {
     const prevTile = prevTilesMap[nextTile.id];
 
-    if (nextTile.mergedFrom && nextTile.mergedFrom.length > 0) {
+    const prevMergedFrom = prevTile?.mergedFrom ?? [];
+    const nextMergedFrom = nextTile.mergedFrom ?? [];
+
+    // Only emit a merge diff if mergedFrom is non-empty and has changed from prev to next
+    if (nextMergedFrom.length > 0 && !isEqual(prevMergedFrom, nextMergedFrom)) {
       diffs.push({
         type: "merge",
         payload: {
           mergedToTileId: nextTile.id,
-          mergedFromTileIds: nextTile.mergedFrom,
+          mergedFromTileIds: nextTile.mergedFrom!,
           newValue: nextTile.value,
           prevValue: prevTile.value,
           mergedToTileBackgroundColor: nextTile.backgroundColor,
@@ -56,6 +61,47 @@ export default function getGameStateDiffs(
           value: nextTile.value,
           backgroundColor: nextTile.backgroundColor,
           textColor: nextTile.textColor,
+        },
+      });
+    }
+  }
+
+  // Check for removed tiles (not merged)
+  // A tile is removed if it was in prev but not in next, and it is NOT part of a merge (i.e., not in any mergedFrom array)
+  const mergedFromTileIds = new Set<number>();
+  for (const nextTile of nextState.tiles) {
+    if (nextTile.mergedFrom && nextTile.mergedFrom.length > 0) {
+      for (const id of nextTile.mergedFrom) {
+        mergedFromTileIds.add(id);
+      }
+    }
+  }
+  for (const prevTile of prevState.tiles) {
+    if (!nextTilesMap[prevTile.id] && !mergedFromTileIds.has(prevTile.id)) {
+      diffs.push({
+        type: "remove",
+        payload: {
+          tileId: prevTile.id,
+        },
+      });
+    }
+  }
+
+  // Check for value changes (not due to merge or move)
+  for (const nextTile of nextState.tiles) {
+    const prevTile = prevTilesMap[nextTile.id];
+    if (
+      prevTile &&
+      prevTile.value !== nextTile.value &&
+      isEqual(prevTile.position, nextTile.position) &&
+      (!nextTile.mergedFrom || nextTile.mergedFrom.length === 0)
+    ) {
+      diffs.push({
+        type: "value-change",
+        payload: {
+          tileId: nextTile.id,
+          prevValue: prevTile.value,
+          newValue: nextTile.value,
         },
       });
     }


### PR DESCRIPTION
## Summary
- add ability to set rows and columns from UI
- expose setters through context
- trigger reset when grid size changes

## Testing
- `npx tsc`
- `npx eslint .`
- `npx jest --ci`
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test:ci` *(fails: This package doesn't seem to be present in your lockfile)*