### PR TITLE
Add fixed tile handling to 2048

### DIFF
--- a/game/games/__tests__/two048.ts
+++ b/game/games/__tests__/two048.ts
@@ -316,6 +316,45 @@ const descriptions: {
     ],
   },
   {
+    title: "Fixed tiles",
+    cases: [
+      {
+        title: "Tile stops before fixed tile when moving up",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [3, 3],
+        prevTiles: [
+          { tileId: 0, value: null, row: 1, column: 0 },
+          { tileId: 1, value: 2, row: 3, column: 0 },
+        ],
+        applyAction: "up",
+        expectedPositions: [
+          { tileId: 0, value: null, row: 1, column: 0 },
+          { tileId: 1, value: 2, row: 2, column: 0 },
+          { tileId: 2, value: 2, row: 3, column: 3 },
+        ],
+        settings: standard2048Settings,
+      },
+      {
+        title: "Tiles separated by fixed tile do not merge",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [1, 2],
+        prevTiles: [
+          { tileId: 0, value: 2, row: 0, column: 0 },
+          { tileId: 1, value: null, row: 0, column: 1 },
+          { tileId: 2, value: 2, row: 0, column: 3 },
+        ],
+        applyAction: "left",
+        expectedPositions: [
+          { tileId: 0, value: 2, row: 0, column: 0 },
+          { tileId: 1, value: null, row: 0, column: 1 },
+          { tileId: 2, value: 2, row: 0, column: 2 },
+          { tileId: 3, value: 2, row: 1, column: 2 },
+        ],
+        settings: standard2048Settings,
+      },
+    ],
+  },
+  {
     title: "End states",
     cases: [
       {

--- a/game/games/two048.ts
+++ b/game/games/two048.ts
@@ -121,17 +121,14 @@ function mergeTiles(
   source: Types.Tile,
   removed: Set<Types.TileId>
 ): { score: number | null; changed: boolean } {
+  // Fixed tiles (value === null) should never merge. Guard against it here.
+  if (target.value === null || source.value === null) {
+    return { score: null, changed: false };
+  }
+
   removed.add(source.id);
 
-  if (target.value === null && source.value === null) {
-    target.value = null;
-  } else if (target.value === null) {
-    target.value = source.value;
-  } else if (source.value === null) {
-    target.value = target.value;
-  } else {
-    target.value += source.value;
-  }
+  target.value += source.value;
 
   const colors = getColorsFromValue(target.value);
   target.backgroundColor = colors.backgroundColor;
@@ -165,6 +162,13 @@ function slideColumn(
   let score = 0;
 
   columnTiles.forEach((tile) => {
+    if (tile.value === null) {
+      // Fixed tile acts as a wall
+      lastTile = null;
+      targetRow = tile.position[0] + step;
+      return;
+    }
+
     if (lastTile && lastTile.value === tile.value && !lastTile.mergedFrom) {
       const result = mergeTiles(lastTile, tile, removed);
 
@@ -194,6 +198,13 @@ function slideRow(
   let score = 0;
 
   rowTiles.forEach((tile) => {
+    if (tile.value === null) {
+      // Fixed tile acts as a wall
+      lastTile = null;
+      targetCol = tile.position[1] + step;
+      return;
+    }
+
     if (lastTile && lastTile.value === tile.value && !lastTile.mergedFrom) {
       const result = mergeTiles(lastTile, tile, removed);
       if (result.score) {


### PR DESCRIPTION
## Summary
- support immovable wall tiles in 2048 logic
- prevent merging with null-valued tiles
- treat null tiles as walls when sliding rows/columns
- add tests covering fixed tile behaviour

## Testing
- `npx tsc`
- `npx eslint .`
- `npx jest --ci`


------
https://chatgpt.com/codex/tasks/task_e_683ad7c1de608324b93fd3b01fdaf958