### PR TITLE
Implement exit location logic in 2048

### DIFF
--- a/components/game/ExitLocation.tsx
+++ b/components/game/ExitLocation.tsx
@@ -24,11 +24,6 @@ export default function ExitLocation({
   value,
   style,
 }: ExitLocationProps): React.ReactNode {
-  console.log("ExitLocation", {
-    index,
-    side,
-  });
-
   const animatedStyle = useAnimatedStyle(() => {
     const width =
       side === "left" || side === "right"

--- a/components/game/ExitLocation.tsx
+++ b/components/game/ExitLocation.tsx
@@ -78,8 +78,8 @@ export default function ExitLocation({
   return (
     <Animated.View style={[styles.container, style, animatedStyle]}>
       <Animated.Text style={[styles.text, textAnimatedStyle]}>
-        Exit {type === "greater-than-equal-to" ? ">=" : ""}
         {value}
+        {type === "greater-than-equal-to" ? "+" : ""}
       </Animated.Text>
     </Animated.View>
   );

--- a/components/game/Game.tsx
+++ b/components/game/Game.tsx
@@ -5,6 +5,7 @@ import {
   useGridSize,
   useSetGridSize,
   useSetGame,
+  useGetTestProps,
 } from "@/components/game/Game.context";
 import games from "@/game/games";
 import GridConnected from "@/components/game/grid/GridConnected";
@@ -15,6 +16,7 @@ import useGameController from "./hooks/useGameController";
 import Number from "@/components/game/Number";
 import { useSharedValue } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import * as Clipboard from "expo-clipboard";
 
 export interface GameProps {}
 
@@ -28,6 +30,17 @@ function ConnectedGame(props: GameProps): React.ReactNode {
   const insets = useSafeAreaInsets();
   const { game, setGame } = useSetGame();
   const selectedGame = game?.name;
+  const getTestProps = useGetTestProps();
+
+  const copyTestProps = React.useCallback(async () => {
+    const testProps = getTestProps();
+
+    const string = JSON.stringify(testProps, null, 2);
+
+    console.log("Test Props:", string);
+
+    await Clipboard.setStringAsync(string);
+  }, [getTestProps]);
 
   const [size, setSize] = React.useState<{
     width: number;
@@ -129,6 +142,9 @@ function ConnectedGame(props: GameProps): React.ReactNode {
         />
 
         <View style={footerStyle}>
+          <View style={styles.reset}>
+            <Button title="Copy Test Props" onPress={copyTestProps} />
+          </View>
           <View style={styles.reset}>
             <Button title="Settings" onPress={openSettings} />
           </View>

--- a/game/games/__tests__/two048.ts
+++ b/game/games/__tests__/two048.ts
@@ -1,6 +1,9 @@
 import withRand from "@/utils/withRand";
 import two048, { getColorsFromValue } from "../two048";
 import * as Types from "@/game/Game.types";
+import getTestPropsFromState, {
+  TilePosition,
+} from "@/game/utils/getTestPropsFromState";
 
 jest.mock("../../utils/getRandomAvailablePosition", () => ({
   __esModule: true,
@@ -9,13 +12,6 @@ jest.mock("../../utils/getRandomAvailablePosition", () => ({
 
 // eslint-disable-next-line import/first
 import getRandomAvailablePosition from "../../utils/getRandomAvailablePosition";
-
-type TilePosition = {
-  tileId: number;
-  value: Types.Value;
-  row: number;
-  column: number;
-};
 
 const standard2048Settings: Types.Settings = {
   newTileValue: 2,
@@ -494,9 +490,7 @@ const descriptions: {
         title: "Tile exits when reaching top exit location",
         gridSize: { rows: 4, columns: 4 },
         randomAvailablePosition: [3, 3],
-        prevTiles: [
-          { tileId: 0, value: 16, row: 1, column: 2 },
-        ],
+        prevTiles: [{ tileId: 0, value: 16, row: 1, column: 2 }],
         applyAction: "up",
         expectedPositions: [
           { tileId: 0, value: 16, row: -1, column: 2 },
@@ -515,9 +509,7 @@ const descriptions: {
         title: "Tile does not exit when value is too low",
         gridSize: { rows: 4, columns: 4 },
         randomAvailablePosition: [3, 3],
-        prevTiles: [
-          { tileId: 0, value: 8, row: 1, column: 2 },
-        ],
+        prevTiles: [{ tileId: 0, value: 8, row: 1, column: 2 }],
         applyAction: "up",
         expectedPositions: [
           { tileId: 0, value: 8, row: 0, column: 2 },
@@ -558,9 +550,7 @@ const descriptions: {
         title: "Tile exits bottom with equal requirement",
         gridSize: { rows: 4, columns: 4 },
         randomAvailablePosition: [0, 0],
-        prevTiles: [
-          { tileId: 0, value: 4, row: 2, column: 0 },
-        ],
+        prevTiles: [{ tileId: 0, value: 4, row: 2, column: 0 }],
         applyAction: "down",
         expectedPositions: [
           { tileId: 0, value: 4, row: 4, column: 0 },
@@ -572,6 +562,29 @@ const descriptions: {
             side: "bottom",
             index: 0,
             requirements: { type: "equal-to", value: 4 },
+          },
+        ],
+      },
+      {
+        title:
+          "Tile does not exit when a valid tile ends up next to the exit location but the action does not move it out",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [3, 3],
+        prevTiles: [
+          { tileId: 0, value: 8, row: 0, column: 2 },
+          { tileId: 1, value: 8, row: 0, column: 3 },
+        ],
+        applyAction: "left",
+        expectedPositions: [
+          { tileId: 0, value: 16, row: 0, column: 0 },
+          { tileId: 2, value: 2, row: 3, column: 3 },
+        ],
+        settings: standard2048Settings,
+        exitLocations: [
+          {
+            side: "top",
+            index: 0,
+            requirements: { type: "greater-than-equal-to", value: 16 },
           },
         ],
       },
@@ -603,23 +616,6 @@ function stateFromTilePositions(
     settings,
     exitLocations,
   };
-}
-
-function tilePositionsFromState(state: Types.GameState): TilePosition[] {
-  const positions: TilePosition[] = [];
-
-  state.tiles.forEach((tile) => {
-    const [row, column] = tile.position;
-
-    positions.push({
-      tileId: tile.id,
-      value: tile.value,
-      row,
-      column,
-    });
-  });
-
-  return positions.sort((a, b) => a.tileId - b.tileId);
 }
 
 describe("two048 game", () => {
@@ -663,7 +659,7 @@ describe("two048 game", () => {
             }
 
             if (expectedPositions) {
-              const nextGrid = tilePositionsFromState(nextState);
+              const nextGrid = getTestPropsFromState(nextState).tiles;
 
               expect(nextGrid).toEqual(expectedPositions);
             }

--- a/game/games/__tests__/two048.ts
+++ b/game/games/__tests__/two048.ts
@@ -588,6 +588,58 @@ const descriptions: {
           },
         ],
       },
+      {
+        title:
+          "A valid exit tile sliding next to an exit location does not leave if the direction does not move it out",
+        gridSize: { rows: 4, columns: 4 },
+        randomAvailablePosition: [1, 2],
+        prevTiles: [
+          {
+            tileId: 0,
+            value: 2,
+            row: 3,
+            column: 0,
+          },
+          {
+            tileId: 1,
+            value: 1,
+            row: 3,
+            column: 1,
+          },
+        ],
+        applyAction: "right",
+        expectedPositions: [
+          {
+            tileId: 0,
+            value: 2,
+            row: 3,
+            column: 2,
+          },
+          {
+            tileId: 1,
+            value: 1,
+            row: 3,
+            column: 3,
+          },
+          {
+            tileId: 2,
+            value: 2,
+            row: 1,
+            column: 2,
+          },
+        ],
+        settings: standard2048Settings,
+        exitLocations: [
+          {
+            requirements: {
+              type: "greater-than-equal-to",
+              value: 2,
+            },
+            side: "bottom",
+            index: 2,
+          },
+        ],
+      },
     ],
   },
 ];

--- a/game/games/two048.ts
+++ b/game/games/two048.ts
@@ -323,9 +323,22 @@ function requirementsMet(
   }
 }
 
+const actionToExitLocationSide: Record<
+  Types.Action,
+  Types.ExitLocation["side"] | null
+> = {
+  up: "top",
+  down: "bottom",
+  left: "left",
+  right: "right",
+  tap: null,
+  tick: null,
+};
+
 function applyExitLocations(
   state: Types.GameState,
-  gridSize: Types.GridSize
+  gridSize: Types.GridSize,
+  action: Types.Action
 ): { changed: boolean } {
   let changed = false;
 
@@ -368,7 +381,8 @@ function applyExitLocations(
     if (
       tile &&
       !tile.mergedFrom &&
-      requirementsMet(tile.value, exit.requirements)
+      requirementsMet(tile.value, exit.requirements) &&
+      actionToExitLocationSide[action] === exit.side
     ) {
       if (moveTile(tile, newRow, newCol)) changed = true;
     }
@@ -488,7 +502,7 @@ const applyAction: Types.ApplyAction = ({ state, action, gridSize, rand }) => {
     score: state.score + scoreIncrease,
   };
 
-  const exitResult = applyExitLocations(nextState, gridSize);
+  const exitResult = applyExitLocations(nextState, gridSize, action);
   const overallChanged = changed || exitResult.changed;
 
   nextState = spawnRandomTile(nextState, gridSize, rand, overallChanged);

--- a/game/games/two048.ts
+++ b/game/games/two048.ts
@@ -100,6 +100,22 @@ const getInitState: Types.GetInitState = ({ rand, gridSize, settings }) => {
         side: "left",
         index: 2,
       },
+      {
+        requirements: {
+          type: "greater-than-equal-to",
+          value: 2,
+        },
+        side: "right",
+        index: 2,
+      },
+      {
+        requirements: {
+          type: "greater-than-equal-to",
+          value: 2,
+        },
+        side: "top",
+        index: 2,
+      },
     ],
   };
 
@@ -491,9 +507,9 @@ const gameConfig: Types.GameConfig = {
     columns: 4,
   },
   defaultSettings: {
-    zeroTiles: true,
+    zeroTiles: false,
     permZeroTileCount: 2,
-    randomFixedTiles: 1,
+    randomFixedTiles: 0,
     newTileValue: 1,
   },
 };

--- a/game/games/two048.ts
+++ b/game/games/two048.ts
@@ -87,9 +87,17 @@ const getInitState: Types.GetInitState = ({ rand, gridSize, settings }) => {
       {
         requirements: {
           type: "greater-than-equal-to",
-          value: 16,
+          value: 2,
         },
-        side: "top",
+        side: "bottom",
+        index: 2,
+      },
+      {
+        requirements: {
+          type: "greater-than-equal-to",
+          value: 2,
+        },
+        side: "left",
         index: 2,
       },
     ],

--- a/game/utils/getTestPropsFromState.ts
+++ b/game/utils/getTestPropsFromState.ts
@@ -1,0 +1,31 @@
+import * as Types from "@/game/Game.types";
+
+export type TilePosition = {
+  tileId: number;
+  value: Types.Value;
+  row: number;
+  column: number;
+};
+
+export type TestProps = {
+  tiles: TilePosition[];
+};
+
+export default function getTestPropsFromState(
+  state: Types.GameState
+): TestProps {
+  const positions: TilePosition[] = [];
+
+  state.tiles.forEach((tile) => {
+    const [row, column] = tile.position;
+
+    positions.push({
+      tileId: tile.id,
+      value: tile.value,
+      row,
+      column,
+    });
+  });
+
+  return { tiles: positions.sort((a, b) => a.tileId - b.tileId) };
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.9",
     "expo-blur": "~14.1.4",
+    "expo-clipboard": "~7.1.4",
     "expo-constants": "~17.1.6",
     "expo-crypto": "~14.1.4",
     "expo-font": "~13.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3664,6 +3664,11 @@ expo-blur@~14.1.4:
   resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-14.1.4.tgz#d246c0a224ce63321d022edfc0e6a8c5fa2cc865"
   integrity sha512-55P9tK/RjJZEcu2tU7BqX3wmIOrGMOOkmHztJMMws+ZGHzvtjnPmT7dsQxhOU9vPj77oHnKetYHU2sik3iBcCw==
 
+expo-clipboard@~7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-7.1.4.tgz#f2cda0d3cbfd2d307aa85dd7ba6843d6bbaf4227"
+  integrity sha512-NHhfKnrzb4o0PacUKD93ByadU0JmPBoFTFYbbFJZ9OAX6SImpSqG5gfrMUR3vVj4Qx9f1LpMcdAv5lBzv868ow==
+
 expo-constants@~17.1.5, expo-constants@~17.1.6:
   version "17.1.6"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-17.1.6.tgz#a31b019216f7f7bb4907aeffa2d6bf856751985e"


### PR DESCRIPTION
## Summary
- add exit location logic to two048 game
- ensure merged tiles do not exit in the same turn
- support exit requirements and multiple locations
- extend tests with scenarios covering tile exit behavior

## Testing
- `yarn lint`
- `npx tsc`
- `yarn test:ci`


------
https://chatgpt.com/codex/tasks/task_e_683aeb0345948324bc23a9fd76002d5b