### PR TITLE
Add win condition when tile exits

### DIFF
--- a/game/games/__tests__/two048.ts
+++ b/game/games/__tests__/two048.ts
@@ -496,6 +496,7 @@ const descriptions: {
           { tileId: 0, value: 16, row: -1, column: 2 },
           { tileId: 1, value: 2, row: 3, column: 3 },
         ],
+        expectedStatus: "won",
         settings: standard2048Settings,
         exitLocations: [
           {
@@ -556,6 +557,7 @@ const descriptions: {
           { tileId: 0, value: 4, row: 4, column: 0 },
           { tileId: 1, value: 2, row: 0, column: 0 },
         ],
+        expectedStatus: "won",
         settings: standard2048Settings,
         exitLocations: [
           {

--- a/game/games/two048.ts
+++ b/game/games/two048.ts
@@ -450,6 +450,18 @@ function resolveEndState(
 ): Types.GameState {
   const { rows, columns } = gridSize;
 
+  const tileExited = state.tiles.some(
+    (t) =>
+      t.position[0] < 0 ||
+      t.position[0] >= rows ||
+      t.position[1] < 0 ||
+      t.position[1] >= columns
+  );
+
+  if (tileExited) {
+    return { ...state, status: "won" };
+  }
+
   if (
     state.tiles.some(
       (t) => t.value !== null && t.value >= getGoalFromGridSize(gridSize)


### PR DESCRIPTION
## Summary
- add win check for exiting tiles in 2048 game
- expect a win when a tile leaves the board

## Testing
- `yarn lint`
- `yarn test:ci`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_683c183abcfc8324913b8d07649dac99