### PR TITLE
Adjust grid spacing for exit locations

### DIFF
--- a/components/game/ExitLocation.tsx
+++ b/components/game/ExitLocation.tsx
@@ -14,7 +14,7 @@ export interface ExitLocationProps {
   tileSize: SharedValue<number>;
 }
 
-const textHeightAllowance = 20;
+export const EXIT_LOCATION_OFFSET = 20;
 
 export default function ExitLocation({
   index,
@@ -27,13 +27,13 @@ export default function ExitLocation({
   const animatedStyle = useAnimatedStyle(() => {
     const width =
       side === "left" || side === "right"
-        ? textHeightAllowance
+        ? EXIT_LOCATION_OFFSET
         : tileSize.value;
 
     const height =
       side === "left" || side === "right"
         ? tileSize.value
-        : textHeightAllowance;
+        : EXIT_LOCATION_OFFSET;
 
     const offset = index * tileSize.value;
 
@@ -41,16 +41,16 @@ export default function ExitLocation({
 
     switch (side) {
       case "top":
-        positionStyle = { top: -textHeightAllowance, left: offset };
+        positionStyle = { top: -EXIT_LOCATION_OFFSET, left: offset };
         break;
       case "bottom":
-        positionStyle = { bottom: -textHeightAllowance, left: offset };
+        positionStyle = { bottom: -EXIT_LOCATION_OFFSET, left: offset };
         break;
       case "left":
-        positionStyle = { left: -textHeightAllowance, top: offset };
+        positionStyle = { left: -EXIT_LOCATION_OFFSET, top: offset };
         break;
       case "right":
-        positionStyle = { right: -textHeightAllowance, top: offset };
+        positionStyle = { right: -EXIT_LOCATION_OFFSET, top: offset };
         break;
     }
 
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   text: {
-    fontSize: Math.min(16, textHeightAllowance),
+    fontSize: Math.min(16, EXIT_LOCATION_OFFSET),
     color: "white",
     textAlign: "center",
     fontWeight: "bold",

--- a/components/game/ExitLocation.tsx
+++ b/components/game/ExitLocation.tsx
@@ -12,6 +12,8 @@ export interface ExitLocationProps {
   index: number;
   style?: StyleProp<ViewStyle>;
   tileSize: SharedValue<number>;
+  columns: number;
+  rows: number;
 }
 
 export const EXIT_LOCATION_OFFSET = 20;
@@ -23,6 +25,8 @@ export default function ExitLocation({
   type,
   value,
   style,
+  columns,
+  rows,
 }: ExitLocationProps): React.ReactNode {
   const animatedStyle = useAnimatedStyle(() => {
     const width =
@@ -41,16 +45,22 @@ export default function ExitLocation({
 
     switch (side) {
       case "top":
-        positionStyle = { top: -EXIT_LOCATION_OFFSET, left: offset };
+        positionStyle = { left: offset + EXIT_LOCATION_OFFSET, top: 0 };
         break;
       case "bottom":
-        positionStyle = { bottom: -EXIT_LOCATION_OFFSET, left: offset };
+        positionStyle = {
+          left: offset + EXIT_LOCATION_OFFSET,
+          top: rows * tileSize.value + EXIT_LOCATION_OFFSET,
+        };
         break;
       case "left":
-        positionStyle = { left: -EXIT_LOCATION_OFFSET, top: offset };
+        positionStyle = { left: 0, top: offset + EXIT_LOCATION_OFFSET };
         break;
       case "right":
-        positionStyle = { right: -EXIT_LOCATION_OFFSET, top: offset };
+        positionStyle = {
+          left: rows * tileSize.value + EXIT_LOCATION_OFFSET,
+          top: offset + EXIT_LOCATION_OFFSET,
+        };
         break;
     }
 

--- a/components/game/Game.context.tsx
+++ b/components/game/Game.context.tsx
@@ -149,6 +149,8 @@ export function GameProvider(props: { children: React.ReactNode }) {
 
   const setAllToCurrentState = React.useCallback(() => {
     setStatus(currentStateRef.current.status);
+    setSettings(currentStateRef.current.settings);
+    setLevel(currentStateRef.current.level);
     score.value = currentStateRef.current.score;
 
     Object.entries(callbacks.current).forEach(([tileIdString, callback]) => {
@@ -201,8 +203,6 @@ export function GameProvider(props: { children: React.ReactNode }) {
         prevStateRef.current = currentStateRef.current;
         currentStateRef.current = nextState;
         nextStateRef.current = null;
-
-        setSettings(currentStateRef.current.settings);
 
         setAllToCurrentState();
 

--- a/components/game/grid/Grid.tsx
+++ b/components/game/grid/Grid.tsx
@@ -68,10 +68,7 @@ export default React.memo(function Grid({
 
   const containerStyle = React.useMemo(
     () =>
-      StyleSheet.flatten([
-        styles.container,
-        { padding: EXIT_LOCATION_OFFSET },
-      ]),
+      StyleSheet.flatten([styles.container, { padding: EXIT_LOCATION_OFFSET }]),
     []
   );
 
@@ -147,6 +144,8 @@ export default React.memo(function Grid({
             type={requirements.type}
             value={requirements.value}
             tileSize={sizeSharedValue}
+            columns={columns}
+            rows={rows}
           />
         ))}
       </View>

--- a/components/game/grid/Grid.tsx
+++ b/components/game/grid/Grid.tsx
@@ -1,5 +1,6 @@
 import ExitLocation, {
   ExitLocationProps,
+  EXIT_LOCATION_OFFSET,
 } from "@/components/game/ExitLocation";
 import TileConnected from "@/components/game/tile/TileConnected";
 import * as GameTypes from "@/game/Game.types";
@@ -34,9 +35,11 @@ export default React.memo(function Grid({
   exitLocations,
 }: GridProps): React.ReactNode {
   const tileSize = React.useMemo((): number => {
+    const spacing = EXIT_LOCATION_OFFSET * 2;
+
     const size = Math.min(
-      availableHeight / rows,
-      availableWidth / columns,
+      (availableHeight - spacing) / rows,
+      (availableWidth - spacing) / columns,
       maxTileSize
     );
 
@@ -61,6 +64,15 @@ export default React.memo(function Grid({
         },
       ]),
     [tileSize, rows, columns]
+  );
+
+  const containerStyle = React.useMemo(
+    () =>
+      StyleSheet.flatten([
+        styles.container,
+        { padding: EXIT_LOCATION_OFFSET },
+      ]),
+    []
   );
 
   const rowStyle = React.useMemo(
@@ -114,7 +126,7 @@ export default React.memo(function Grid({
 
   return (
     <GestureDetector gesture={gesture}>
-      <View style={styles.container}>
+      <View style={containerStyle}>
         <View style={innerStyle}>
           {rowIds.map((rowId) => (
             <View key={rowId} style={rowStyle}>


### PR DESCRIPTION
## Summary
- export `EXIT_LOCATION_OFFSET` constant
- apply padding around Grid and account for spacing in tile calculations

## Testing
- `yarn lint`
- `yarn test:ci` *(fails: Game won tests expect `won` but got `user-turn`)*
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_683d2f6ae5408324a8a48273d91a717e