### PR TITLE
Fix two048 test types

### DIFF
--- a/game/games/__tests__/two048.ts
+++ b/game/games/__tests__/two048.ts
@@ -31,7 +31,7 @@ const descriptions: {
   cases: {
     title: string;
     prevTiles: TilePosition[];
-    applyAction: Types.Action;
+    applyAction: Types.RegularActionType;
     randomAvailablePosition: Types.Position | null;
     expectedPositions?: TilePosition[];
     expectedStatus?: Types.GameState["status"];
@@ -715,7 +715,7 @@ describe("two048 game", () => {
 
             const nextState = two048.applyAction({
               state: prevState,
-              action: applyAction,
+              type: applyAction,
             });
 
             if (expectedStatus) {


### PR DESCRIPTION
## Summary
- update `game/games/__tests__/two048.ts` to use `RegularActionType`
- pass the action type correctly when invoking `applyAction`

## Testing
- `yarn lint` *(fails: command not found)*
- `yarn test:ci` *(fails: command not found)*
- `npx tsc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d27683f48324b8f6981ecc10c2c5