### PR TITLE
Fix exit location position with rectangular grids

### DIFF
--- a/components/game/ExitLocation.tsx
+++ b/components/game/ExitLocation.tsx
@@ -58,7 +58,7 @@ export default function ExitLocation({
         break;
       case "right":
         positionStyle = {
-          left: rows * tileSize.value + EXIT_LOCATION_OFFSET,
+          left: columns * tileSize.value + EXIT_LOCATION_OFFSET,
           top: offset + EXIT_LOCATION_OFFSET,
         };
         break;


### PR DESCRIPTION
## Summary
- correct the right-side exit location offset to use columns

## Testing
- `npm run test:ci`
- `npx eslint .`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_685a5704227483248a3c1e74d1c7f581